### PR TITLE
feat(hal,transport): add 0x502B (M1 V5 TMR) to DONGLE_PIDS in both registries

### DIFF
--- a/iot_driver_linux/monsgeek-transport/src/device_registry.rs
+++ b/iot_driver_linux/monsgeek-transport/src/device_registry.rs
@@ -15,6 +15,7 @@ pub const DONGLE_PIDS: &[u16] = &[
     0x5038, // M1 V5 HE dongle
     0x503A, // Legacy dongle variant
     0x503D, // Legacy dongle variant
+    0x502B, // M1 V5 TMR dongle
 ];
 
 /// Known Bluetooth PIDs (BLE HID connections via HOGP)

--- a/iot_driver_linux/src/hal/constants.rs
+++ b/iot_driver_linux/src/hal/constants.rs
@@ -21,6 +21,7 @@ pub const DONGLE_PIDS: &[u16] = &[
     0x5038, // M1 V5 HE dongle
     0x503A, // Legacy dongle variant
     0x503D, // Legacy dongle variant
+    0x502B, // M1 V5 TMR dongle
 ];
 
 /// Check if PID represents a 2.4GHz dongle


### PR DESCRIPTION
## Summary

The MonsGeek M1 V5 TMR's 2.4G dongle enumerates as `VID:PID 3151:502B`. Two separate `DONGLE_PIDS` lists need this PID:

1. `iot_driver_linux/src/hal/constants.rs` — used by the CLI battery command's vendor protocol path.
2. `iot_driver_linux/monsgeek-transport/src/device_registry.rs` — used by the discovery layer to set `TransportType::HidDongle` (drives gRPC / web-app integration and dongle-specific commands).

Without (1), `iot_driver battery --vendor` returned "no dongle found".
Without (2), the device was reported as `type=HidWired` and the gRPC discovery / web-app path treated it as a wired device.

Both lists are independent of `get_device_id()` — they only drive transport-type classification.

## Test plan

- [x] Built with `make driver` and installed.
- [x] `iot_driver info` now correctly reports `type=HidDongle`:

```
Device:    MonsGeek 2.4G Wireless Keyboard
  VID/PID:  3151:502B  type=HidDongle
Firmware:  v4.00 (raw 0x0400, dec 1024)
Device ID: 2679 (0x00000A77)
```

- [x] `iot_driver battery` (without `--vendor`) now succeeds via the standard path:

```
Battery Status (vendor)
-----------------------
  Level:     79%
  Connected: Yes
  Idle:      No (active)
```

- [x] Other commands (`set-led`, `all`, etc.) continue working over the dongle.

The eBPF battery loader (`akko-loader`) still hardcodes `PID_DONGLE = 0x5038` and is intentionally left untouched in this PR — that path needs a wider change and a kernel-side test on the relevant variant.