### PR TITLE
Support for Attack Shark K86

### DIFF
--- a/iot_driver_linux/monsgeek-transport/src/device_registry.rs
+++ b/iot_driver_linux/monsgeek-transport/src/device_registry.rs
@@ -16,6 +16,7 @@ pub const DONGLE_PIDS: &[u16] = &[
     0x503A, // Legacy dongle variant
     0x503D, // Legacy dongle variant
     0x502B, // M1 V5 TMR dongle
+    0x5006, // Attack Shark K86 dongle
 ];
 
 /// Known Bluetooth PIDs (BLE HID connections via HOGP)

--- a/iot_driver_linux/src/hal/constants.rs
+++ b/iot_driver_linux/src/hal/constants.rs
@@ -22,6 +22,7 @@ pub const DONGLE_PIDS: &[u16] = &[
     0x503A, // Legacy dongle variant
     0x503D, // Legacy dongle variant
     0x502B, // M1 V5 TMR dongle
+    0x5006, // AttackShark K86 dongle
 ];
 
 /// Check if PID represents a 2.4GHz dongle


### PR DESCRIPTION
Works out of the box. Just submitting the patches for the battery reporting to work. Testing out iot_driver battery seems to give the correct results.
```shell 
iot_driver battery

Battery Status (vendor)
-----------------------
  Level:     99%
  Connected: Yes
  Idle:      No (active)
  Raw[1..8]: 63 00 00 01 01 01 7b

iot_driver

Device:    2.4G Wireless Keyboard
  VID/PID:  3151:5006  type=HidDongle
Firmware:  v1.21 (raw 0x0115, dec 277)
Device ID: 2730 (0x00000AAA)
Protocol:  RY5088
Boot mode: No
API ID:    2730
Patch:     Stock firmware (no patch support).
           0xE7 response (64 bytes): e7 00 00 00 00 00 00 18 00 00 00 00 00 00 00 00
Dongle:    Stock firmware (no patch support).

```